### PR TITLE
Test cleanup tests revisited 115

### DIFF
--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -8,14 +8,14 @@ from config import (find_repo_root, supported_dates,
                     Latest, get_latest_date)
 
 
-#HS: tests for the supported_dates added, the ones from 
-#    the old DateHelper module removed
-# FIXME: this can be combined in class Test_supported_dates 
-def test_supported_dates_starts_in_2009_4():
-    assert supported_dates()[0] == (2009, 4)
+#HS: tests for the supported_dates combined in a class 
+class Test_supported_dates(): 
+    
+    def test_supported_dates_starts_in_2009_4(self):
+        assert supported_dates()[0] == (2009, 4)
 
-def test_supported_dates_excludes_2013_11():
-    assert (2013, 11) not in supported_dates()
+    def test_supported_dates_excludes_2013_11(self):
+        assert (2013, 11) not in supported_dates()
 
 # WONTFIX: what is happening in this test, why is it skipped? should this test be deleted?      
 #          the problem may be related to https://github.com/mini-kep/parser-rosstat-kep/issues/110 

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -73,7 +73,7 @@ class Test_LocalCSV():
 
     def test_processed_method_returns_df_a_q_m_csv(self):
         for freq in 'aqm':
-            expected_name = 'df' + freq + '.csv'
+            expected_name = 'df{}.csv'.format(freq)
             processed_csv = LocalCSV(2015, 5).processed(freq) 
             assert processed_csv.name == expected_name
 
@@ -86,7 +86,7 @@ class Test_Latest():
 
     def test_csv_method_returns_df_a_q_m_csv(self):
         for freq in 'aqm':
-            expected_name = 'df' + freq + '.csv'
+            expected_name = 'df{}.csv'.format(freq)
             Latest_csv = Latest.csv(freq)
             assert Latest_csv.name == expected_name
 

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -1,8 +1,5 @@
 import pytest
 
-# EP: is this used in test?
-import datetime as dt
-
 from config import (find_repo_root, supported_dates,
                     DataFolder, LocalCSV,
                     Latest, get_latest_date)
@@ -17,9 +14,11 @@ class Test_supported_dates():
     def test_supported_dates_excludes_2013_11(self):
         assert (2013, 11) not in supported_dates()
 
-# WONTFIX: what is happening in this test, why is it skipped? should this test be deleted?      
+# WONTFIX: The supported_dates() finishes with the current date,
+#          while the data in 'data/interim' is up to 10.2017.
 #          the problem may be related to https://github.com/mini-kep/parser-rosstat-kep/issues/110 
-@pytest.mark.skip(reason="The data ends with 10.2017")
+# Skip the test until the problem is resolved.      
+@pytest.mark.skip(reason="The data after 10.2017 is not available")
 def test_supported_dates_ends_with_latest_date():
     base_dir = find_repo_root()
     latest_year, latest_month = get_latest_date(base_dir / 'data' / 'interim')
@@ -42,9 +41,7 @@ class Test_DataFolder():
     
     # WONTFIX: three tests below be parametrised 
     def test_get_raw_property_method_returns_existing_folder(self):
-        # EP: this is a call of code under test
         raw_folder = DataFolder(2015, 5).raw
-        # EP: this is a check, they should be separated accorting to guidelines
         assert raw_folder.exists()
     
     def test_get_interim_property_method_returns_existing_folder(self):
@@ -57,25 +54,42 @@ class Test_DataFolder():
 
     def test_out_of_range_year_does_raises_error(self):
         with pytest.raises(ValueError):
-            # EP: slightly better with current year + 1
-            DataFolder(2088, 1)
+            DataFolder(2018, 1)
 
 class Test_LocalCSV():
     def test_get_interim_property_method_returns_existing_file(self):
         interim_csv = LocalCSV(2015, 5).interim 
         assert interim_csv.exists()
 
+    def test_get_interim_property_method_returns_tab_csv(self):
+        interim_csv = LocalCSV(2015, 5).interim
+        expected_name = 'tab.csv'
+        assert interim_csv.name == expected_name
+
     def test_processed_method_returns_existing_files(self):
         for freq in 'aqm':
             processed_csv = LocalCSV(2015, 5).processed(freq) 
             assert processed_csv.exists()
 
-    # FIMXE: can also check interim and process file names        
+    def test_processed_method_returns_df_a_q_m_csv(self):
+        for freq in 'aqm':
+            expected_name = 'df' + freq + '.csv'
+            processed_csv = LocalCSV(2015, 5).processed(freq) 
+            assert processed_csv.name == expected_name
+
 
 class Test_Latest():
     def test_csv_method_returns_existing_files(self):
         for freq in 'aqm':
-            assert Latest.csv(freq).exists()
+            Latest_csv = Latest.csv(freq)
+            assert Latest_csv.exists()
+
+    def test_csv_method_returns_df_a_q_m_csv(self):
+        for freq in 'aqm':
+            expected_name = 'df' + freq + '.csv'
+            Latest_csv = Latest.csv(freq)
+            assert Latest_csv.name == expected_name
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
The supported_dates tests are combined in a class. The file name checks are added for the files in the interim, processed and latest folders.