### PR TITLE
Validation clean up

### DIFF
--- a/src/kep/validation/checkpoints.py
+++ b/src/kep/validation/checkpoints.py
@@ -257,17 +257,19 @@ def validate(df, checkpoints):
         raise ValueError(f"Variables not covered by checkpoints: {uncovered}")
 
 
-# TODO: use *strong* parameter to raise exceptions, print warnings on optional checks otherwise
-def validate2(df, default_checkpoints, optional_checkpoints, strong=False):
+def validate2(df, default_checkpoints, optional_checkpoints, strict_validation=False):
     missed_required = find_missed_checkpoints(df, default_checkpoints)
     missed_optional = find_missed_checkpoints(df, optional_checkpoints)
 
     # FIXME:
     #   - write func docstring
 
-    # onkery: now validation logic simply discards any missed optional checkpoints
-    if missed_required:
-        raise ValueError(f"Required checkpoints not found in dataframe: {missed_required}")
+    if missed_required or missed_optional and strict_validation:
+        missed = missed_required.union(missed_optional)
+        raise ValueError(f"Checkpoints not found in dataframe: {missed}")
+
+    if missed_optional and not strict_validation:
+        raise RuntimeWarning(f"Optional checkpoints not found in dataframe: {missed_optional}")
 
     uncovered_required = find_uncovered_column_names(df, default_checkpoints)
     uncovered_optional = find_uncovered_column_names(df, optional_checkpoints)

--- a/src/kep/validation/checkpoints.py
+++ b/src/kep/validation/checkpoints.py
@@ -260,9 +260,12 @@ def validate(df, checkpoints):
 def validate2(df, required_checkpoints, optional_checkpoints, strict_validation=False):
     """
     Validates given dataframe *df* against *required_checkpoints* and *optional_checkpoints*.
-    If any required checkpoint is missed, raises ValueError with missed checkpoints.
 
+    If any required checkpoint is missed, raises ValueError with missed checkpoints.
     *strict_validation* flag controls validation strictness for optional checkpoints.
+
+    After that function checks if dataframe *df* contains any variables which
+    are not covered by passed checkpoints (both required and optional).
 
     Args:
         df: parsing result as Pandas dataframe

--- a/src/kep/validation/checkpoints.py
+++ b/src/kep/validation/checkpoints.py
@@ -256,19 +256,16 @@ def validate(df, checkpoints):
     if uncovered:
         raise ValueError(f"Variables not covered by checkpoints: {uncovered}")
 
-# TODO: use *strong* parameter to raise exceptions, print warnings on optional checks otherwise  
+
+# TODO: use *strong* parameter to raise exceptions, print warnings on optional checks otherwise
 def validate2(df, default_checkpoints, optional_checkpoints, strong=False):
     missed_required = find_missed_checkpoints(df, default_checkpoints)
     missed_optional = find_missed_checkpoints(df, optional_checkpoints)
 
     # FIXME:
     #   - write func docstring
-    #   - sort out comments in func body
 
     # onkery: now validation logic simply discards any missed optional checkpoints
-    # SUGGESTION: maybe we could show Warnings for missed optional checkpoints
-
-    # ensure a variable in dataframe is covered by at least one checkpoint
     if missed_required:
         raise ValueError(f"Required checkpoints not found in dataframe: {missed_required}")
 
@@ -279,6 +276,7 @@ def validate2(df, default_checkpoints, optional_checkpoints, strong=False):
     # are not covered by both required AND optional checkpoints.
     uncovered = uncovered_required.intersection(uncovered_optional)
 
+    # ensure a variable in dataframe is covered by at least one checkpoint
     if uncovered:
         raise ValueError(f"Variables not covered by checkpoints: {uncovered}")
 

--- a/src/kep/validation/checkpoints.py
+++ b/src/kep/validation/checkpoints.py
@@ -257,12 +257,25 @@ def validate(df, checkpoints):
         raise ValueError(f"Variables not covered by checkpoints: {uncovered}")
 
 
-def validate2(df, default_checkpoints, optional_checkpoints, strict_validation=False):
-    missed_required = find_missed_checkpoints(df, default_checkpoints)
-    missed_optional = find_missed_checkpoints(df, optional_checkpoints)
+def validate2(df, required_checkpoints, optional_checkpoints, strict_validation=False):
+    """
+    Validates given dataframe *df* against *required_checkpoints* and *optional_checkpoints*.
+    If any required checkpoint is missed, raises ValueError with missed checkpoints.
 
-    # FIXME:
-    #   - write func docstring
+    *strict_validation* flag controls validation strictness for optional checkpoints.
+
+    Args:
+        df: parsing result as Pandas dataframe
+        required_checkpoints: list of dictionaries with required checkpoints
+        optional_checkpoints: list of dictionaries with optional checkpoints
+        strict_validation: if set, function raises exception on any missed
+        optional checkpoint and only shows warning otherwise
+
+    Returns:
+        None
+    """
+    missed_required = find_missed_checkpoints(df, required_checkpoints)
+    missed_optional = find_missed_checkpoints(df, optional_checkpoints)
 
     if missed_required or missed_optional and strict_validation:
         missed = missed_required.union(missed_optional)
@@ -271,7 +284,7 @@ def validate2(df, default_checkpoints, optional_checkpoints, strict_validation=F
     if missed_optional and not strict_validation:
         raise RuntimeWarning(f"Optional checkpoints not found in dataframe: {missed_optional}")
 
-    uncovered_required = find_uncovered_column_names(df, default_checkpoints)
+    uncovered_required = find_uncovered_column_names(df, required_checkpoints)
     uncovered_optional = find_uncovered_column_names(df, optional_checkpoints)
 
     # onkery: `intersection` here because we need to find columns which

--- a/src/kep/vintage.py
+++ b/src/kep/vintage.py
@@ -51,11 +51,7 @@ class Vintage:
             try:
                 validate2(df, required, optional)            
             except ValueError as err:
-                # EP: в чем смысл сообщения? рассказать о контексте ошибки? 
-                #     f"Validated frequency: '{freq}'" - ничего про ошибку не говорит,                 
-                #     а для диагностики все равно недостаточно. может не надо тут validate2
-                #     в try-except оборачивать?
-                raise ValueError(f"Validated frequency: '{freq}'") from err
+                raise ValueError(f"Validation error occurred at frequency: '{freq}'") from err
 
         print("Test values parsed OK for", self)
 


### PR DESCRIPTION
In this PR:
- more clear error message for `validate` method on `Vintage`
- more intuitively ordered comments in `validate2`
- `strict_validation` (`strong` previously) flag implementation
- docstring for `validate2`
